### PR TITLE
Run yarn before running prepublish

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-cd deploy_repo && npm-publish-prerelease
+cd deploy_repo && \
+	yarn && \
+	npm-publish-prerelease


### PR DESCRIPTION
Previously we were not running yarn and the transpile step would silently exit.